### PR TITLE
feat(setlistfm-js): Add option to specify a base url

### DIFF
--- a/lib/setlistfm.js
+++ b/lib/setlistfm.js
@@ -27,7 +27,7 @@ SOFTWARE.
 
 // Static Variables
 var version = "1.0";
-var baseUrl = "https://api.setlist.fm/rest/";
+var defaultBaseUrl = "https://api.setlist.fm/rest/";
 var paths = {
   getArtist: "/artist/%s",
   getArtistSetlists: "/artist/%s/setlists",
@@ -372,7 +372,7 @@ var SetlistFmApi = function(config) {
 
   // Private functions
   function buildUrl(endpoint, variable) {
-    return baseUrl + version + endpoint.replace("%s", variable);
+    return self.baseUrl + version + endpoint.replace("%s", variable);
   }
 
   function requestApi(endpoint, variables) {
@@ -399,6 +399,11 @@ var SetlistFmApi = function(config) {
 }
 
   // Constructor Actions
+  self.baseUrl = defaultBaseUrl;
+  if (typeof config !== "undefined" && typeof config.baseUrl !== "undefined") {
+    self.baseUrl = config.baseUrl || defaultBaseUrl;
+  }
+
   if (typeof config !== "undefined" && typeof config.key !== "undefined") {
     self.key = config.key;
   }

--- a/lib/setlistfm.js
+++ b/lib/setlistfm.js
@@ -394,7 +394,7 @@ var SetlistFmApi = function(config) {
           return response;
         })
         .catch(function(error) {
-          console.error("setlist.fm API Error: Could not reach API.");
+          console.error("setlist.fm API Error: Could not reach API.", error);
         });
 }
 


### PR DESCRIPTION
setlist.fm is blocking API requests because of CORS https://www.setlist.fm/forum/setlistfm/setlistfm-api/api-cross-origin-request-blocked-1bd6c540

This allows you to set a different baseUrl so you can mirror their API on your server and avoid exposing your API key.